### PR TITLE
Update GitHub workflow trigger branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Build/Release
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   release:


### PR DESCRIPTION
The GitHub workflow has been adjusted to trigger on push to 'master' instead of 'main'. This change aligns with our standard branch setup and ensures that the automated workflow runs as expected on the correct branches.