### PR TITLE
Update package version and release settings

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -25,7 +25,7 @@
       "owner": "SchraderR",
       "private": true,
       "protocol": "https",
-      "releaseType": "prerelease"
+      "releaseType": "release"
     }
   },
   "mac": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sp-tarkov-client",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "EFT-SP Management Tool",
   "author": "Schrader",
   "main": "app/main.js",
@@ -25,7 +25,7 @@
     "electron:serve-tsc": "tsc -p tsconfig.serve.json",
     "electron:serve": "wait-on tcp:4200 && npm run electron:serve-tsc && electron . --serve",
     "electron:local": "npm run build:prod && electron . --serve",
-    "electron:build": "npm run build:prod && electron-builder build --publish=never",
+    "electron:build": "npm run build:prod && electron-builder build --publish=always",
     "test": "ng test --watch=false",
     "test:watch": "ng test",
     "lint": "ng lint"


### PR DESCRIPTION
This commit updates the package version from 0.0.1 to 0.0.2 and changes the package's build strategy to always publish. Additionally, the electron-builder.json file has been modified to change the release type from "prerelease" to "release".