### PR TITLE
Simplify production build command and update build action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,12 @@ jobs:
           node-version: '18'
 
       - name: Build/release Electron app
-        uses: coparse-inc/action-electron-builder@v1.0.0
+        uses: samuelmeuli/action-electron-builder@v1
         with:
           # GitHub token, automatically provided to the action
           # (No need to define this secret in the repo settings)
           github_token: ${{ secrets.github_token }}
-          build_script_name: "electron:build"
+          build_script_name: "build:prod"
 
           # If the commit is tagged with a version (e.g. "v1.0.0"),
           # release the app after building

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -16,9 +16,7 @@
   ],
   "win": {
     "icon": "dist/assets/icons",
-    "target": [
-      "nsis"
-    ],
+    "target": ["nsis"],
     "publish": {
       "provider": "github",
       "repo": "sp-tarkov-client",
@@ -28,16 +26,4 @@
       "releaseType": "release"
     }
   },
-  "mac": {
-    "icon": "dist/assets/icons",
-    "target": [
-      "dmg"
-    ]
-  },
-  "linux": {
-    "icon": "dist/assets/icons",
-    "target": [
-      "AppImage"
-    ]
-  }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ng:serve": "ng serve -c web",
     "build": "npm run electron:serve-tsc && ng build --base-href ./",
     "build:dev": "npm run build -- -c dev",
-    "build:prod": "npm run build -- -c production",
+    "build:prod": "ng build",
     "web:build": "npm run build -- -c web-production",
     "electron": "electron",
     "electron:serve-tsc": "tsc -p tsconfig.serve.json",


### PR DESCRIPTION
The production build command in package.json has been simplified to use 'ng build' for streamlining. We have also updated the Electron build action in the GitHub Workflow to align with this change. Additionally, the target settings for Mac and Linux in the electron-builder.json file have been removed.