### PR TITLE
Update app version and GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,13 @@ jobs:
           node-version: '18'
 
       - name: Build/release Electron app
-        uses: samuelmeuli/action-electron-builder@v1
+        uses: samuelmeuli/action-electron-builder@v1.6.0
         with:
           # GitHub token, automatically provided to the action
           # (No need to define this secret in the repo settings)
           github_token: ${{ secrets.github_token }}
           build_script_name: "build:prod"
+          args: --publish=always
 
           # If the commit is tagged with a version (e.g. "v1.0.0"),
           # release the app after building

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sp-tarkov-client",
   "description": "EFT-SP Management Tool",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "main": "main.js",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
The application version was updated in package.json from "0.0.1" to "0.0.3". Also, in .github/workflows/main.yml, the version for the action-electron-builder was specified to "v1.6.0" and an argument to always publish was added. This indicates that the app should be released after building whenever a commit is tagged with a version.