### PR TITLE
Speed up mod information fetch during install

### DIFF
--- a/app/events/indexed-mods.event.ts
+++ b/app/events/indexed-mods.event.ts
@@ -1,0 +1,23 @@
+import { UserSettingStoreModel } from '../../shared/models/user-setting.model';
+import { ipcMain } from 'electron';
+import * as Store from 'electron-store';
+
+export const handleIndexedModsEvents = (store: Store<UserSettingStoreModel>) => {
+    ipcMain.on('use-indexed-mods-save', (event, value) => {
+        try {
+            store.set('useIndexedMods', value);
+            event.sender.send('use-indexed-mods-save-completed');
+        } catch (error) {
+            event.sender.send('use-indexed-mods-save-error', error);
+        }
+    });
+
+    ipcMain.on('use-indexed-mods', event => {
+        try {
+            const useIndexedMods = store.get('useIndexedMods');
+            event.sender.send('use-indexed-mods-completed', useIndexedMods);
+        } catch (error) {
+            event.sender.send('use-indexed-mods-error', error);
+        }
+    });
+}

--- a/app/main.ts
+++ b/app/main.ts
@@ -21,6 +21,7 @@ import { handleUpdateModEvents } from './events/update-mod.event';
 import { handleAkiTagEvents } from './events/aki-tag.event';
 import { handleAkiVersionEvents } from './events/aki-version.event';
 import { handleModCacheEvents } from './events/mod-list-cache.event';
+import { handleIndexedModsEvents } from './events/indexed-mods.event';
 log.initialize();
 
 const isServe = process.argv.slice(1).some(val => val === '--serve');
@@ -46,3 +47,4 @@ handleUpdateModEvents(store);
 handleAkiTagEvents(store);
 handleAkiVersionEvents(store);
 handleModCacheEvents(store);
+handleIndexedModsEvents(store);

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sp-tarkov-client",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sp-tarkov-client",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
         "@types/adm-zip": "^0.5.5",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sp-tarkov-client",
   "description": "EFT-SP Management Tool",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "main": "main.js",
   "private": true,
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sp-tarkov-client",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sp-tarkov-client",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "17.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sp-tarkov-client",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "SP-EFT Manager",
   "author": {
     "name": "Schrader",

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,4 +1,10 @@
 {
+  "/mods.json": {
+    "target": "https://hub.sp-tarkov.com",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  },
   "/files": {
     "target": "https://hub.sp-tarkov.com",
     "secure": false,

--- a/shared/models/aki-core.model.ts
+++ b/shared/models/aki-core.model.ts
@@ -17,6 +17,7 @@ export interface DownloadModel {
 export interface LinkModel {
   fileId: string;
   akiInstancePath: string;
+  downloadUrl: string;
 }
 
 export interface AkiVersion {

--- a/shared/models/user-setting.model.ts
+++ b/shared/models/user-setting.model.ts
@@ -28,6 +28,7 @@ export interface UserSettingStoreModel {
   akiVersions: AkiVersion[];
   akiTags: AkiTag[];
   modCache: ModCache[];
+  useIndexedMods: boolean;
 }
 
 export interface AkiInstance {

--- a/src/app/components/mod-card/mod-card.component.ts
+++ b/src/app/components/mod-card/mod-card.component.ts
@@ -65,6 +65,8 @@ export class ModCardComponent implements OnInit {
         const modLicenceBox = modPageView.body.querySelector('.boxContent dl dd:first-of-type a');
 
         this.mod.supportedAkiVersion = supportedVersion;
+        this.mod.version = modPageView.body.getElementsByClassName('filebaseVersionNumber')[0].innerHTML ?? "";
+        
         return {
           url: modLicenceBox?.getAttribute('href') ?? this.mod.fileUrl,
           text: modLicenceBox?.innerHTML ?? 'SP Hub-License',

--- a/src/app/components/mod-card/mod-card.component.ts
+++ b/src/app/components/mod-card/mod-card.component.ts
@@ -65,7 +65,7 @@ export class ModCardComponent implements OnInit {
         const modLicenceBox = modPageView.body.querySelector('.boxContent dl dd:first-of-type a');
 
         this.mod.supportedAkiVersion = supportedVersion;
-        this.mod.version = modPageView.body.getElementsByClassName('filebaseVersionNumber')[0].innerHTML ?? "";
+        this.mod.modVersion = modPageView.body.getElementsByClassName('filebaseVersionNumber')[0].innerHTML ?? "";
         
         return {
           url: modLicenceBox?.getAttribute('href') ?? this.mod.fileUrl,

--- a/src/app/components/mod-list/mod-list.component.html
+++ b/src/app/components/mod-list/mod-list.component.html
@@ -7,6 +7,9 @@
 @if (modListSignal().length) {
   <div class="button-container">
     <button mat-icon-button color="accent" [disabled]="(isDownloadingAndInstalling$ | async) || !isModCompleted()" (click)="removeCompletedMods()" matTooltip="Remove all completed Mods"><mat-icon>scan_delete</mat-icon></button>
+    <mat-slide-toggle 
+    [formControl]="useIndexedModsControl"  (change)="onUseIndexedModsToggle($event)"  matTooltipClass="tooltip-multiline" 
+    [matTooltip]="'Use information from an indexed list. The normal process will be used as a fallback.\n\nThis mod list is updated every hour and might not be in sync with the hub.\n\nUse with caution.'">Use indexed mods</mat-slide-toggle>
     <button mat-raised-button color="accent" [disabled]="(isDownloadingAndInstalling$ | async) || !isModNotCompleted()" (click)="downloadAndInstallAll()">Download / Install</button>
   </div>
 }

--- a/src/app/components/mod-list/mod-list.component.spec.ts
+++ b/src/app/components/mod-list/mod-list.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import ModListComponent from './mod-list.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('ModListComponent', () => {
   let component: ModListComponent;
@@ -8,7 +9,7 @@ describe('ModListComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, ModListComponent],
+      imports: [NoopAnimationsModule, ModListComponent, HttpClientTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ModListComponent);

--- a/src/app/core/events/electron.events.ts
+++ b/src/app/core/events/electron.events.ts
@@ -28,7 +28,9 @@
   | 'aki-tags-save'
   | 'mod-list-cache'
   | 'add-mod-list-cache'
-  | 'remove-mod-list-cache';
+  | 'remove-mod-list-cache'
+  | 'use-indexed-mods'
+  | 'use-indexed-mods-save';
 
 export type applicationElectronFileProgressEventNames = 'download-mod-progress' | 'download-mod-direct' | 'download-mod-direct-completed';
 export type applicationTarkovInstanceOutputEventNames = 'server-output' | 'server-output-completed';

--- a/src/app/core/models/mod.ts
+++ b/src/app/core/models/mod.ts
@@ -3,6 +3,7 @@ import { Kind } from '../../../../shared/models/unzip.model';
 
 export interface Mod {
   name: string;
+  version?: string;
   fileUrl: string;
   kind: Kind | undefined;
   notSupported: boolean;

--- a/src/app/core/models/mod.ts
+++ b/src/app/core/models/mod.ts
@@ -3,7 +3,7 @@ import { Kind } from '../../../../shared/models/unzip.model';
 
 export interface Mod {
   name: string;
-  version?: string;
+  modVersion?: string;
   fileUrl: string;
   kind: Kind | undefined;
   notSupported: boolean;

--- a/src/app/core/services/download.service.spec.ts
+++ b/src/app/core/services/download.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';  // Import HttpClientTestingModule
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DownloadService } from './download.service';
 
 describe('DownloadService', () => {

--- a/src/app/core/services/download.service.spec.ts
+++ b/src/app/core/services/download.service.spec.ts
@@ -1,12 +1,14 @@
 import { TestBed } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';  // Import HttpClientTestingModule
 import { DownloadService } from './download.service';
 
 describe('DownloadService', () => {
   let service: DownloadService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(DownloadService);
   });
 

--- a/src/app/core/services/mod-list.service.ts
+++ b/src/app/core/services/mod-list.service.ts
@@ -6,8 +6,14 @@ import { InstallProgress, Mod } from '../models/mod';
 })
 export class ModListService {
   private modList = signal<Mod[]>([]);
+  private useIndexedMods = signal<boolean>(false);
   readonly modListSignal = this.modList.asReadonly();
+  readonly useIndexedModsSignal = this.useIndexedMods.asReadonly();
 
+  setUseIndexedMods(value: boolean) {
+    this.useIndexedMods.set(value);
+  }
+  
   addMod(mod: Mod) {
     if (this.modList().some(m => m.name === mod.name)) {
       return;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -6,4 +6,5 @@ export const environment = {
   akiFileBaseLink: 'https://hub.sp-tarkov.com/files',
   akiFileTagBaseLink: 'https://hub.sp-tarkov.com/tagged/',
   githubConfigLink: 'https://schraderr.github.io/sp-tarkov-client-configuration',
+  akiHubModsJson: 'https://hub.sp-tarkov.com/mods.json'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,4 +6,5 @@ export const environment = {
   akiFileBaseLink: '/files/',
   akiFileTagBaseLink: '/tagged/',
   githubConfigLink: '/sp-tarkov-client-configuration',
+  akiHubModsJson: '/mods.json'
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { TranslocoHttpLoader } from './transloco-loader';
 import { provideTransloco } from '@jsverse/transloco';
 import { ConfigurationService } from './app/core/services/configuration.service';
 import { forkJoin } from 'rxjs';
+import { DownloadService } from './app/core/services/download.service';
 
 if (environment.production) {
   enableProdMode();
@@ -37,10 +38,20 @@ bootstrapApplication(AppComponent, {
       deps: [ConfigurationService],
       multi: true,
     },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: modDataLoaderFactory,
+      deps: [DownloadService],
+      multi: true,
+    },
   ],
 }).catch(err => console.error(err));
 
 function configurationServiceFactory(configurationService: ConfigurationService) {
   return () =>
     forkJoin([configurationService.getCurrentConfiguration(), configurationService.getAkiVersion(), configurationService.getCurrentTags()]);
+}
+
+function modDataLoaderFactory(downloadService: DownloadService) {
+  return () => downloadService.getModData();
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -29,6 +29,10 @@ body {
   }
 }
 
+.tooltip-multiline {
+  white-space: pre-line;
+}
+
 .github-info-panel {
   color: white;
   padding: 8px;


### PR DESCRIPTION
Hub has this mods.json with many useful information available very quickly: 
https://hub.sp-tarkov.com/mods.json

I figured it could be used to fetch the last version's direct download link, instead of reading it through a headless browser, which was by far the slowest part of installing/updating mods. It is now near instantaneous.

Workflow:

1. Read out latest mod version in getModVersionAndLicenseInformation (Need version from normal mod hub to not download an older version which wasn't updated yet in the json as it's a 1 or 2 hours behind the actual mod hub.)
2. When user clicks 'Download / Install', fetch the latest mods.json.
3. During install, find the mod data by name. 
4. If version of a mod matches the version in the mod_data json, pass the download link to the download-link which will process it without needing to read it using the Browser.

To avoid users downloading an older version accidentally, we still have to rely on the actual mod hub page, but maybe another extra feature could be added in the future, something like "Use indexed mods" that could skip the entire /files/file/ query and version check and force the installer to use the latest link from mods.json. This would be useful in case the hub is overloaded and stops working - the mod manager could still work with direct links.